### PR TITLE
Preserve code blocks in exported conversations

### DIFF
--- a/src/export/export.css
+++ b/src/export/export.css
@@ -34,6 +34,22 @@ body {
 
 .msg p { margin: 6px 0; }
 .msg a { text-decoration: underline; }
+.msg pre {
+  margin: 8px 0;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: #f5f7fa;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 10pt;
+}
+.msg code {
+  font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+  background: #eef1f4;
+  padding: 0 3px;
+  border-radius: 4px;
+}
 
 @media print {
   .header { position: static; }


### PR DESCRIPTION
## Summary
- allow pre/code-related tags through sanitisation and preserve whitespace when replacing disallowed elements
- add multiline fallbacks that wrap text in <pre> where needed and style pre/code blocks for readable PDF output

## Testing
- node /tmp/jsdom-test/verify.js

------
https://chatgpt.com/codex/tasks/task_e_68dcd020ae64832a8aa56f80eef2de17