### PR TITLE
Expand domain support to chatgpt.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
     "activeTab"
   ],
   "host_permissions": [
-    "https://chat.openai.com/*"
+    "https://chat.openai.com/*",
+    "https://chatgpt.com/*"
   ],
   "background": {
     "service_worker": "src/background/sw.js",
@@ -19,7 +20,10 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://chat.openai.com/*"],
+      "matches": [
+        "https://chat.openai.com/*",
+        "https://chatgpt.com/*"
+      ],
       "js": ["src/content/content.js"],
       "css": ["src/content/injectButton.css"],
       "run_at": "document_end"


### PR DESCRIPTION
## Summary
- include chatgpt.com in host permissions so the extension can run on the new domain
- update the content script matches to inject functionality on chatgpt.com conversations

## Testing
- not run (extension changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dcd0007bf0832ab4fd9d3f218f3cd4