### PR TITLE
Fix duplicate messages and improve page breaking in export

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -13,15 +13,13 @@
   // —— 最小抽取：把页面上的“消息块”按顺序抓成 text/html ——
   function extractMinimalConversation() {
     // 选取候选消息容器（不同 UI 可能不同；这里做并联）
-    const nodes = [];
-    const sels = [
-      '[data-message-author-role]', // 常见
-      'article'                     // 有时每条消息是 article
-    ];
-    sels.forEach(sel => {
-      document.querySelectorAll(sel).forEach(n => {
-        if (!nodes.includes(n)) nodes.push(n);
-      });
+    let nodes = Array.from(document.querySelectorAll('[data-message-author-role]'));
+    if (!nodes.length) {
+      nodes = Array.from(document.querySelectorAll('article'));
+    }
+
+    nodes = nodes.filter((node, index, arr) => {
+      return !arr.some((other, otherIndex) => otherIndex !== index && other.contains(node));
     });
 
     // 依据文档顺序排列

--- a/src/export/export.css
+++ b/src/export/export.css
@@ -25,7 +25,8 @@ body {
   margin: 12px 0 18px;
   padding: 10px 12px;
   border-radius: 10px;
-  break-inside: avoid;
+  break-inside: auto;
+  page-break-inside: auto;
 }
 .msg .role { font-size: 9pt; color: #666; margin-bottom: 6px; }
 


### PR DESCRIPTION
## Summary
- avoid collecting both article wrappers and message nodes to stop duplicated entries
- relax page-break rules on message cards so long replies can span multiple pages without blank gaps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd79ef124832aab164864fc94f46f