### PR TITLE
Update export bubbles layout

### DIFF
--- a/src/export/export.css
+++ b/src/export/export.css
@@ -22,20 +22,31 @@ body {
 .container { max-width: 900px; margin: 0 auto; }
 
 .msg {
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
   margin: 12px 0 18px;
-  padding: 10px 12px;
-  border-radius: 10px;
-  break-inside: auto;
-  page-break-inside: auto;
+  break-inside: avoid;
+  page-break-inside: avoid;
 }
-.msg .role { font-size: 9pt; color: #666; margin-bottom: 6px; }
+.msg.user { justify-content: flex-end; }
+.msg.assistant { justify-content: flex-start; }
 
-.msg.user { background: #f7f7f9; }
-.msg.assistant { background: #f1f8ff; }
+.bubble {
+  border-radius: 12px;
+  padding: 10px 14px;
+  background: #fff;
+  break-inside: avoid;
+  page-break-inside: avoid;
+  box-shadow: 0 0 0 1px #ebedf0;
+  max-width: 100%;
+}
+.msg.user .bubble { background: #f5f5f7; }
+.msg.assistant .bubble { background: #fff; }
 
-.msg p { margin: 6px 0; }
-.msg a { text-decoration: underline; }
-.msg pre {
+.bubble p { margin: 6px 0; }
+.bubble a { text-decoration: underline; }
+.bubble pre {
   margin: 8px 0;
   padding: 8px 10px;
   border-radius: 6px;
@@ -45,7 +56,7 @@ body {
   font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
   font-size: 10pt;
 }
-.msg code {
+.bubble code {
   font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
   background: #eef1f4;
   padding: 0 3px;

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -26,7 +26,6 @@ function render(conversation) {
   // 消息
   const app = document.getElementById('app');
   app.innerHTML = (conversation.items || []).map(item => {
-    const roleLabel = item.role === 'user' ? '用户' : '助手';
     // 当前最小版：只渲染 text 块（下一轮会支持代码、表格、图片、公式等）
     const htmlBlocks = (item.blocks || []).map(b => {
       if (b.type === 'text' && b.html) return b.html;
@@ -36,8 +35,7 @@ function render(conversation) {
     }).join('\n');
     return `
       <section class="msg ${item.role}">
-        <div class="role">${roleLabel}</div>
-        ${htmlBlocks}
+        <div class="bubble">${htmlBlocks}</div>
       </section>
     `;
   }).join('\n');


### PR DESCRIPTION
## Summary
- wrap exported message content in a bubble element without rendering role labels
- restyle messages to align user content to the right and assistant content to the left with shared bubble styling
- ensure bubble layout keeps spacing of text and code blocks while avoiding awkward page breaks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de6adcad3c832aac205ce27dea29ec