### PR TITLE
Sync export document title with rendered conversation title

### DIFF
--- a/src/export/export.html
+++ b/src/export/export.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>导出预览 | ChatGPT → PDF</title>
+  <title>加载中…</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="./export.css">
 </head>

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -17,6 +17,7 @@ function render(conversation) {
   const link  = conversation.sourceUrl || '';
 
   document.getElementById('doc-title').textContent = title;
+  document.title = title;
   const timeEl = document.getElementById('doc-time');
   timeEl.textContent = `导出时间：${time}`;
   const linkEl = document.getElementById('doc-link');


### PR DESCRIPTION
## Summary
- synchronize the printed document title with the rendered conversation title
- use a neutral placeholder title in export.html before scripts execute

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de6adc9df4832a9d8961193ec52e46