### PR TITLE
Remove export header metadata fields

### DIFF
--- a/src/export/export.css
+++ b/src/export/export.css
@@ -16,8 +16,6 @@ body {
   margin-bottom: 12px;
 }
 .header h1 { margin: 0 0 6px; font-size: 18pt; }
-.header .meta { color: #555; font-size: 9pt; }
-.header a { text-decoration: underline; }
 
 .container { max-width: 900px; margin: 0 auto; }
 

--- a/src/export/export.html
+++ b/src/export/export.html
@@ -9,10 +9,6 @@
 <body>
   <header class="header">
     <h1 id="doc-title">对话导出</h1>
-    <div class="meta">
-      <span id="doc-time"></span>
-      <span> · 来源：<a id="doc-link" target="_blank" rel="noopener noreferrer"></a></span>
-    </div>
   </header>
 
   <main id="app" class="container">

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -11,17 +11,7 @@ function escapeHtml(s='') {
 function render(conversation) {
   // 顶部信息
   const title = conversation.title || 'ChatGPT 对话导出';
-  const time  = conversation.exportedAt
-    ? new Date(conversation.exportedAt).toLocaleString()
-    : new Date().toLocaleString();
-  const link  = conversation.sourceUrl || '';
-
   document.getElementById('doc-title').textContent = title;
-  const timeEl = document.getElementById('doc-time');
-  timeEl.textContent = `导出时间：${time}`;
-  const linkEl = document.getElementById('doc-link');
-  linkEl.textContent = link;
-  linkEl.href = link;
 
   // 消息
   const app = document.getElementById('app');


### PR DESCRIPTION
## Summary
- remove the export metadata block from the preview header and leave only the title element
- simplify the export renderer to stop populating time and link metadata
- clean up styles that targeted the removed metadata elements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de6adc406c832aa3f4c0299359c908