### PR TITLE
Simplify export header

### DIFF
--- a/src/export/export.css
+++ b/src/export/export.css
@@ -15,9 +15,10 @@ body {
   border-bottom: 1px solid #eee;
   margin-bottom: 12px;
 }
-.header h1 { margin: 0 0 6px; font-size: 18pt; }
-.header .meta { color: #555; font-size: 9pt; }
-.header a { text-decoration: underline; }
+.header h1 {
+  margin: 0;
+  font-size: 18pt;
+}
 
 .container { max-width: 900px; margin: 0 auto; }
 

--- a/src/export/export.html
+++ b/src/export/export.html
@@ -9,10 +9,6 @@
 <body>
   <header class="header">
     <h1 id="doc-title">对话导出</h1>
-    <div class="meta">
-      <span id="doc-time"></span>
-      <span> · 来源：<a id="doc-link" target="_blank" rel="noopener noreferrer"></a></span>
-    </div>
   </header>
 
   <main id="app" class="container">

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -11,18 +11,9 @@ function escapeHtml(s='') {
 function render(conversation) {
   // 顶部信息
   const title = conversation.title || 'ChatGPT 对话导出';
-  const time  = conversation.exportedAt
-    ? new Date(conversation.exportedAt).toLocaleString()
-    : new Date().toLocaleString();
-  const link  = conversation.sourceUrl || '';
 
   document.getElementById('doc-title').textContent = title;
   document.title = title;
-  const timeEl = document.getElementById('doc-time');
-  timeEl.textContent = `导出时间：${time}`;
-  const linkEl = document.getElementById('doc-link');
-  linkEl.textContent = link;
-  linkEl.href = link;
 
   // 消息
   const app = document.getElementById('app');


### PR DESCRIPTION
## Summary
- remove the time/link metadata container from the export header and associated script logic
- clean up header styling now that only the conversation title remains

## Testing
- Manual export run via Playwright with stubbed chrome APIs to verify the page renders with only the title and still triggers printing

------
https://chatgpt.com/codex/tasks/task_e_68dec6c6da4c832aa9742f5222d6ddaa