### PR TITLE
Preserve ChatGPT image wrappers during message sanitization

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -51,8 +51,10 @@
       // 只保留简单标签，其他降级为文本
       const ALLOW = new Set([
         'P','A','STRONG','B','EM','I','U','S','UL','OL','LI','BLOCKQUOTE','BR',
-        'H1','H2','H3','H4','H5','H6','PRE','CODE','KBD','SAMP','IMG'
+        'H1','H2','H3','H4','H5','H6','PRE','CODE','KBD','SAMP','IMG',
+        'FIGURE','FIGCAPTION','PICTURE','SOURCE'
       ]);
+      const KEEP_STRUCTURE = new Set(['FIGURE', 'FIGCAPTION', 'PICTURE']);
       const walker = document.createTreeWalker(frag, NodeFilter.SHOW_ELEMENT);
       const toReplace = [];
       while (walker.nextNode()) {
@@ -154,6 +156,10 @@
         }
       }
       toReplace.forEach(n => {
+        if (KEEP_STRUCTURE.has(n.tagName)) {
+          n.replaceWith(...Array.from(n.childNodes));
+          return;
+        }
         const text = n.textContent || '';
         const withinCode = typeof n.closest === 'function' ? n.closest('pre, code') : null;
 


### PR DESCRIPTION
## Summary
- allow common ChatGPT image wrapper tags so responsive images survive sanitization
- add a safeguard to flatten preserved wrappers instead of dropping their child nodes if encountered during replacement

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfaa54ab88832a9fbbc8dfe640450d