### PR TITLE
Flatten disallowed wrappers that contain allowed content

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -51,8 +51,12 @@
       // 只保留简单标签，其他降级为文本
       const ALLOW = new Set([
         'P','A','STRONG','B','EM','I','U','S','UL','OL','LI','BLOCKQUOTE','BR',
-        'H1','H2','H3','H4','H5','H6','PRE','CODE','KBD','SAMP','IMG'
+        'H1','H2','H3','H4','H5','H6','PRE','CODE','KBD','SAMP','IMG',
+        'FIGURE','FIGCAPTION','PICTURE','SOURCE'
       ]);
+      const allowedDescendantSelector = Array.from(ALLOW)
+        .map(tag => tag.toLowerCase())
+        .join(',');
       const walker = document.createTreeWalker(frag, NodeFilter.SHOW_ELEMENT);
       const toReplace = [];
       while (walker.nextNode()) {
@@ -154,6 +158,14 @@
         }
       }
       toReplace.forEach(n => {
+        const shouldPreserveChildren =
+          typeof n.querySelector === 'function' &&
+          allowedDescendantSelector &&
+          n.querySelector(allowedDescendantSelector);
+        if (shouldPreserveChildren) {
+          n.replaceWith(...Array.from(n.childNodes));
+          return;
+        }
         const text = n.textContent || '';
         const withinCode = typeof n.closest === 'function' ? n.closest('pre, code') : null;
 


### PR DESCRIPTION
## Summary
- derive a selector for allowed tags within the conversation sanitizer
- flatten disallowed wrapper nodes when they contain allowed descendants so nested images survive cleanup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfaa54ab88832a9fbbc8dfe640450d