### PR TITLE
Add image support to exported conversations

### DIFF
--- a/src/export/export.css
+++ b/src/export/export.css
@@ -44,6 +44,32 @@ body {
 
 .bubble p { margin: 6px 0; }
 .bubble a { text-decoration: underline; }
+.bubble img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 8px 0;
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+.bubble picture {
+  display: block;
+  margin: 8px 0;
+}
+.bubble figure {
+  margin: 10px 0;
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+.bubble figure img {
+  margin: 0 auto;
+}
+.bubble figcaption {
+  margin-top: 6px;
+  font-size: 10pt;
+  color: #555;
+  text-align: center;
+}
 .bubble pre {
   margin: 8px 0;
   padding: 8px 10px;


### PR DESCRIPTION
## Summary
- keep image tags when scraping ChatGPT messages, sanitising attributes and normalising sources
- update the export renderer and stylesheet to display conversation images and wait for them to load before printing

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df9fd4c5fc832aa8b0b0b6771432d0