### PR TITLE
Add image support to PDF export

### DIFF
--- a/src/export/export.css
+++ b/src/export/export.css
@@ -61,6 +61,33 @@ body {
   border-radius: 4px;
 }
 
+.bubble figure {
+  margin: 12px 0;
+}
+
+.bubble figure.image-block {
+  margin: 14px 0;
+}
+
+.bubble img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 10px 0;
+  border-radius: 10px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.04);
+  background: #fff;
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+.bubble figcaption {
+  margin-top: 6px;
+  font-size: 10pt;
+  color: #666;
+  text-align: center;
+}
+
 @media print {
   .header { position: static; }
 }

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -5,7 +5,58 @@ function getQuery(key) {
 }
 
 function escapeHtml(s='') {
-  return s.replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+  return s.replace(/[&<>\"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+}
+
+function renderImageBlock(block) {
+  if (!block?.src) {
+    const altText = block?.alt ? `图片：${block.alt}` : '图片缺失';
+    return `<p>${escapeHtml(altText)}</p>`;
+  }
+
+  const attrs = [];
+  const alt = 'alt' in block ? String(block.alt ?? '') : '';
+  attrs.push(`src="${escapeHtml(String(block.src))}"`);
+  attrs.push(`alt="${escapeHtml(alt)}"`);
+  if (block.srcset) attrs.push(`srcset="${escapeHtml(String(block.srcset))}"`);
+  if (block.sizes) attrs.push(`sizes="${escapeHtml(String(block.sizes))}"`);
+  if (block.width) attrs.push(`width="${escapeHtml(String(block.width))}"`);
+  if (block.height) attrs.push(`height="${escapeHtml(String(block.height))}"`);
+
+  const imgHtml = `<img ${attrs.join(' ')}>`;
+  const caption = block.caption ? `<figcaption>${escapeHtml(String(block.caption))}</figcaption>` : '';
+  return `<figure class="image-block">${imgHtml}${caption}</figure>`;
+}
+
+function waitForImages(root = document, timeout = 7000) {
+  const images = Array.from(root.querySelectorAll('img'));
+  if (!images.length) return Promise.resolve();
+
+  return Promise.all(images.map(img => new Promise(resolve => {
+    if (img.complete && img.naturalWidth !== 0) {
+      resolve();
+      return;
+    }
+    if (img.complete && img.naturalWidth === 0) {
+      resolve();
+      return;
+    }
+
+    let done = false;
+    let timer;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      if (timer) clearTimeout(timer);
+      img.removeEventListener('load', onEvent);
+      img.removeEventListener('error', onEvent);
+      resolve();
+    };
+    const onEvent = () => finish();
+    img.addEventListener('load', onEvent, { once: true });
+    img.addEventListener('error', onEvent, { once: true });
+    timer = setTimeout(finish, timeout);
+  }))).then(() => undefined);
 }
 
 function render(conversation) {
@@ -17,10 +68,11 @@ function render(conversation) {
   // 消息
   const app = document.getElementById('app');
   app.innerHTML = (conversation.items || []).map(item => {
-    // 当前最小版：只渲染 text 块（下一轮会支持代码、表格、图片、公式等）
+    // 当前版本：渲染文本与图片块（后续可扩展表格、代码等）
     const htmlBlocks = (item.blocks || []).map(b => {
       if (b.type === 'text' && b.html) return b.html;
       if (b.type === 'text' && b.text) return `<p>${escapeHtml(b.text)}</p>`;
+      if (b.type === 'image') return renderImageBlock(b);
       // 其它类型暂时保底展示为纯文本提示
       return '';
     }).join('\n');
@@ -48,8 +100,9 @@ async function main() {
 
   render(conversation);
 
-  // 资源准备好后触发打印（此处最小版，后续会等待图片/公式渲染）
-  setTimeout(() => window.print(), 200);
+  // 资源准备好后触发打印：等待图片加载完成或超时
+  await waitForImages(document);
+  window.print();
 
   // 打印触发后清理临时数据（异步）
   chrome.runtime.sendMessage({ type: 'CLEANUP', key }).catch(()=>{});


### PR DESCRIPTION
## Summary
- retain image elements during content extraction with sanitized attributes
- update the exporter to render images and await their loading before printing
- add export styles to ensure images print cleanly alongside captions

## Testing
- not run (extension code change only)


------
https://chatgpt.com/codex/tasks/task_e_68dfd8b67c28832a8279d51f6cdd6067