### PR TITLE
Remove role labels from exported messages

### DIFF
--- a/src/export/export.css
+++ b/src/export/export.css
@@ -27,7 +27,6 @@ body {
   border-radius: 10px;
   break-inside: avoid;
 }
-.msg .role { font-size: 9pt; color: #666; margin-bottom: 6px; }
 
 .msg.user { background: #f7f7f9; }
 .msg.assistant { background: #f1f8ff; }

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -46,11 +46,9 @@ function render(conversation) {
 
   const app = document.getElementById('app');
   app.innerHTML = (conversation.items || []).map(item => {
-    const roleLabel = item.role === 'user' ? '用户' : '助手';
     const blocksHTML = renderBlocks(item.blocks);
     return `
       <section class="msg ${item.role}">
-        <div class="role">${roleLabel}</div>
         ${blocksHTML}
       </section>
     `;


### PR DESCRIPTION
## Summary
- remove the role label markup from each exported message so only content renders
- clean up the export stylesheet by deleting the unused role label styles

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e23a486218832a9d7817e595eddf65