### PR TITLE
Set print title from conversation name

### DIFF
--- a/src/export/export.js
+++ b/src/export/export.js
@@ -39,6 +39,10 @@ function render(conversation) {
     : new Date().toLocaleString();
   const link  = conversation.sourceUrl || '';
 
+  try {
+    document.title = title;
+  } catch {}
+
   document.getElementById('doc-title').textContent = title;
   document.getElementById('doc-time').textContent = `导出时间：${time}`;
   const linkEl = document.getElementById('doc-link');


### PR DESCRIPTION
## Summary
- set the export page document title from the conversation name so the print dialog suggests it as the file name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2414dc208832ab762df2ae72f0fd1