### PR TITLE
Capture image dimensions for export rendering

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -121,6 +121,29 @@
     return url;
   }
 
+  function getRenderedImageSize(imgEl) {
+    if (!imgEl) return {};
+    let width;
+    let height;
+    try {
+      const rect = imgEl.getBoundingClientRect?.();
+      if (rect && rect.width > 0 && rect.height > 0) {
+        width = rect.width;
+        height = rect.height;
+      }
+    } catch {}
+    const w = Number(imgEl.width || imgEl.naturalWidth || 0);
+    const h = Number(imgEl.height || imgEl.naturalHeight || 0);
+    if (!width && w > 0) width = w;
+    if (!height && h > 0) height = h;
+    const roundedWidth = Number.isFinite(width) && width > 0 ? Math.round(width) : undefined;
+    const roundedHeight = Number.isFinite(height) && height > 0 ? Math.round(height) : undefined;
+    return {
+      width: roundedWidth,
+      height: roundedHeight
+    };
+  }
+
   // ============ chatgpt.com 后端临时签名图：强制转 data: ============
   function isEphemeralChatgptImage(url) {
     try {
@@ -201,18 +224,24 @@
       } else if (tag === 'figure') {
         const img = origNode.querySelector('img');
         if (img) {
+          const { width, height } = getRenderedImageSize(img);
           blocksInOrder.push({
             type: 'image',
             src: normalizeImageUrl(img),
             alt: img.getAttribute('alt') || '',
-            caption: (origNode.querySelector('figcaption')?.textContent || '').trim() || undefined
+            caption: (origNode.querySelector('figcaption')?.textContent || '').trim() || undefined,
+            width,
+            height
           });
         }
       } else if (tag === 'img') {
+        const { width, height } = getRenderedImageSize(origNode);
         blocksInOrder.push({
           type: 'image',
           src: normalizeImageUrl(origNode),
-          alt: origNode.getAttribute('alt') || ''
+          alt: origNode.getAttribute('alt') || '',
+          width,
+          height
         });
       } else if (origNode.classList?.contains('katex') || origNode.querySelector?.('.katex')) {
         const container = origNode.classList.contains('katex') ? origNode : origNode.querySelector('.katex');

--- a/src/export/export.css
+++ b/src/export/export.css
@@ -34,6 +34,17 @@ body {
 .msg p { margin: 6px 0; }
 .msg a { text-decoration: underline; }
 
+.msg figure {
+  margin: 10px 0;
+}
+
+.msg img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}
+
 @media print {
   .header { position: static; }
 }

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -14,8 +14,10 @@ function renderBlocks(blocks) {
     } else if (b.type === 'image' && b.src) {
       const cap = b.caption ? `<figcaption>${escapeHtml(b.caption)}</figcaption>` : '';
       const alt = b.alt ? ` alt="${escapeHtml(b.alt)}"` : '';
+      const widthAttr = Number.isFinite(b.width) && b.width > 0 ? ` width="${Math.round(b.width)}"` : '';
+      const heightAttr = Number.isFinite(b.height) && b.height > 0 ? ` height="${Math.round(b.height)}"` : '';
       // 关键：避免 Referer 干扰
-      out.push(`<figure><img referrerpolicy="no-referrer" src="${b.src}"${alt}>${cap}</figure>`);
+      out.push(`<figure><img referrerpolicy="no-referrer" src="${b.src}"${alt}${widthAttr}${heightAttr}>${cap}</figure>`);
     } else if (b.type === 'code' && b.code) {
       const langClass = b.lang ? ` class="language-${b.lang}"` : '';
       out.push(`<pre><code${langClass}>${escapeHtml(b.code)}</code></pre>`);


### PR DESCRIPTION
## Summary
- capture rendered image dimensions during content extraction and store them on image blocks
- preserve and reuse stored width/height when rendering export markup, adding guards for missing metadata
- adjust export styles so sized images stay centered and within the container

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e263332d4c832ab3d2ae59777f9549