### PR TITLE
Adjust export message bubble layout

### DIFF
--- a/src/export/export.css
+++ b/src/export/export.css
@@ -19,17 +19,33 @@ body {
 .header .meta { color: #555; font-size: 9pt; }
 .header a { text-decoration: underline; }
 
-.container { max-width: 900px; margin: 0 auto; }
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+}
 
 .msg {
   margin: 12px 0 18px;
   padding: 10px 12px;
   border-radius: 10px;
   break-inside: auto;
+  display: inline-block;
+  max-width: 66%;
+  width: fit-content;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
-.msg.user { background: #f7f7f9; }
-.msg.assistant { background: #ffffff; }
+.msg.user {
+  background: #f7f7f9;
+  margin-left: auto;
+  margin-right: 0;
+  text-align: left;
+}
+.msg.assistant {
+  background: #ffffff;
+  margin-right: auto;
+}
 
 .msg p { margin: 6px 0; }
 .msg a { text-decoration: underline; }


### PR DESCRIPTION
## Summary
- limit exported message bubble width to two-thirds of the page and allow it to shrink to content
- align user messages to the right while keeping assistant messages on the left
- improve word wrapping to avoid long strings breaking the layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e29ed44830832aac757103c365b257