### PR TITLE
Handle inline source badges

### DIFF
--- a/src/export/export.css
+++ b/src/export/export.css
@@ -45,6 +45,14 @@ body {
   margin: 0 auto;
 }
 
+.msg img[data-cg2pdf-badge] {
+  display: inline-block;
+  vertical-align: middle;
+  margin: 0 4px 0 0;
+  max-height: 48px;
+  width: auto;
+}
+
 @media print {
   .header { position: static; }
 }


### PR DESCRIPTION
## Summary
- allow inline badge icons through rich-text sanitization while stripping extraneous attributes
- detect small favicon/source badges and keep them inline in message HTML
- style preserved badge icons so they align with surrounding text

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2a3915cf4832a988721be449c2c07